### PR TITLE
Fix bem-config default object

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -40,7 +40,7 @@ Filter.prototype = {
      * @private
      */
     _byBlock: function(item) {
-        return this._shouldPass(item, 'blocks', 'block');
+        return this._shouldPass(item.entity, 'blocks', 'block');
     },
 
     /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -49,7 +49,7 @@ exports.conditionsFromBEMItems = function(items) {
  * @returns {Object}
  */
 exports.initializeConfig = function(config) {
-    config = config.extended;
+    config = config.extended || {};
 
     /**
      * Returns list of levels

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "JSONStream": "^1.0.7",
     "bem-config": "git://github.com/bem-incubator/bem-config.git",
     "bem-naming": "^0.5.1",
-    "bem-walk": "0.0.4",
+    "bem-walk": "1.0.0-1",
     "chalk": "^1.1.1",
     "coa": "^1.0.1",
     "flow-tostring": "^1.0.1",


### PR DESCRIPTION
Сейчас в коде поддержана сарая версия bem-config и код не может работать с текущей версией bem-config. Поддерживать новое API смысла нет, так как оно активно меняется и дорабатывается. Предлагаю пока сделать такое решение.